### PR TITLE
PGN dump: support initial Black to move

### DIFF
--- a/src/main/scala/scalachessjs/Main.scala
+++ b/src/main/scala/scalachessjs/Main.scala
@@ -126,7 +126,7 @@ object Main extends JSApp {
             val date = payload.date.asInstanceOf[js.UndefOr[String]].toOption
             Replay(pgnMoves, initialFen, variant getOrElse Variant.default) match {
               case Success(Reader.Result.Complete(replay)) => {
-                val pgn = PgnDump(replay.state, initialFen, replay.setup.startedAtTurn + 1, white, black, date)
+                val pgn = PgnDump(replay.state, initialFen, replay.setup.startedAtTurn, white, black, date)
                 self.postMessage(Message(
                   reqid = reqidOpt,
                   topic = "pgnDump",

--- a/src/main/scala/scalachessjs/PgnDump.scala
+++ b/src/main/scala/scalachessjs/PgnDump.scala
@@ -41,13 +41,15 @@ object PgnDump {
       ))
   }
 
-  private def turns(moves: Vector[String], from: Int): List[chessPgn.Turn] =
-    (moves grouped 2).zipWithIndex.toList map {
+  private def turns(moves: Vector[String], from: Int): List[chessPgn.Turn] = {
+    val paddedMoves = if (from % 2 == 1) ".." +: moves else moves
+    (paddedMoves grouped 2).zipWithIndex.toList map {
       case (moves, index) => chessPgn.Turn(
-        number = index + from,
+        number = index + 1 + (from / 2),
         white = moves.headOption.filter(".." !=).map(s => chessPgn.Move(s)),
         black = moves.lift(1).map(s => chessPgn.Move(s)))
     } filterNot (_.isEmpty)
+  }
 
   private def result(game: Game) = game.situation.status.fold("*") { _ =>
     game.situation.winner.fold("1/2-1/2")(c => c.fold("1-0", "0-1"))


### PR DESCRIPTION
Closes #2 . Please forgive my Scala, I'm a noob and don't know the idioms at all.

Tested with the following payloads:

<details>
  <summary>1. Start from ply 2</summary>

Payload:
```
{
  initialFen: 'rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq - 0 1',
  pgnMoves: ["d5", "Nc3", "Nf6"]
}
```
Response:
```
[Event "Casual Game"]
[Site "https://lichess.org"]
[Date "5/11/2021, 9:56:13 AM"]
[White "Anonymous"]
[Black "Anonymous"]
[Result "*"]
[PlyCount "4"]
[FEN "rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq - 0 1"]
[Variant "Standard"]
[Termination "?"]

1... d5 2. Nc3 Nf6 *
```
</details>

<details>
  <summary>2. Start from ply 1</summary>

Payload:
```
{
  initialFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
  pgnMoves: ["e4", "d6", "d4", "g6", "Nc3", "Nf6", "f4", "Bg7", "Nf3", "c5", "dxc5", "Qa5", "Bd3", "Qxc5", "Qe2", "O-O", "Be3", "Qa5", "O-O", "Bg4", "Rad1", "Nc6", "Bc4", "Nh5", "Bb3", "Bxc3", "bxc3", "Qxc3", "f5", "Nf6", "h3", "Bxf3", "Qxf3", "Na5", "Rd3", "Qc7", "Bh6", "Nxb3", "cxb3", "Qc5+", "Kh1", "Qe5", "Bxf8", "Rxf8", "Re3", "Rc8", "fxg6", "hxg6", "Qf4", "Qxf4", "Rxf4", "Nd7", "Rf2", "Ne5", "Kh2", "Rc1", "Ree2", "Nc6", "Rc2", "Re1", "Rfe2", "Ra1", "Kg3", "Kg7", "Rcd2", "Rf1", "Rf2", "Re1", "Rfe2", "Rf1", "Re3", "a6", "Rc3", "Re1", "Rc4", "Rf1", "Rdc2", "Ra1", "Rf2", "Re1", "Rfc2", "g5", "Rc1", "Re2", "R1c2", "Re1", "Rc1", "Re2", "R1c2", "Re1", "Rc1"],
}
```

Response:
```
[Event "Casual Game"]
[Site "https://lichess.org"]
[Date "5/11/2021, 9:56:13 AM"]
[White "Anonymous"]
[Black "Anonymous"]
[Result "*"]
[PlyCount "91"]
[FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"]
[Variant "Standard"]
[Termination "?"]

1. e4 d6 2. d4 g6 3. Nc3 Nf6 4. f4 Bg7 5. Nf3 c5 6. dxc5 Qa5 7. Bd3 Qxc5 8. Qe2 O-O 9. Be3 Qa5 10. O-O Bg4 11. Rad1 Nc6 12. Bc4 Nh5 13. Bb3 Bxc3 14. bxc3 Qxc3 15. f5 Nf6 16. h3 Bxf3 17. Qxf3 Na5 18. Rd3 Qc7 19. Bh6 Nxb3 20. cxb3 Qc5+ 21. Kh1 Qe5 22. Bxf8 Rxf8 23. Re3 Rc8 24. fxg6 hxg6 25. Qf4 Qxf4 26. Rxf4 Nd7 27. Rf2 Ne5 28. Kh2 Rc1 29. Ree2 Nc6 30. Rc2 Re1 31. Rfe2 Ra1 32. Kg3 Kg7 33. Rcd2 Rf1 34. Rf2 Re1 35. Rfe2 Rf1 36. Re3 a6 37. Rc3 Re1 38. Rc4 Rf1 39. Rdc2 Ra1 40. Rf2 Re1 41. Rfc2 g5 42. Rc1 Re2 43. R1c2 Re1 44. Rc1 Re2 45. R1c2 Re1 46. Rc1 *
```
</details>

<details>
  <summary>3. Start from ply 5</summary>

Payload:
```
{
  initialFen: 'rnbqkb1r/ppp1pppp/5n2/3p4/3P4/2N5/PPP1PPPP/R1BQKBNR w KQkq - 2 3',
  pgnMoves: ["Nf3", "Nc6"],
}
```
Response:
```
[Event "Casual Game"]
[Site "https://lichess.org"]
[Date "5/11/2021, 9:56:13 AM"]
[White "Anonymous"]
[Black "Anonymous"]
[Result "*"]
[PlyCount "6"]
[FEN "rnbqkb1r/ppp1pppp/5n2/3p4/3P4/2N5/PPP1PPPP/R1BQKBNR w KQkq - 2 3"]
[Variant "Standard"]
[Termination "?"]

3. Nf3 Nc6 *
```
</details>

<details>
  <summary>4. Start from ply 4</summary>

Payload:
```
{
  initialFen: 'rnbqkbnr/ppp1pppp/8/3p4/3P4/2N5/PPP1PPPP/R1BQKBNR b KQkq - 1 2',
  pgnMoves: ["Nf6", "Nf3"],
}
```

Response:
```
[Event "Casual Game"]
[Site "https://lichess.org"]
[Date "5/11/2021, 9:56:13 AM"]
[White "Anonymous"]
[Black "Anonymous"]
[Result "*"]
[PlyCount "5"]
[FEN "rnbqkbnr/ppp1pppp/8/3p4/3P4/2N5/PPP1PPPP/R1BQKBNR b KQkq - 1 2"]
[Variant "Standard"]
[Termination "?"]

2... Nf6 3. Nf3 *
```
</details>